### PR TITLE
Add advise flag for resource recommendation

### DIFF
--- a/cmd/kube-resource-explorer/main.go
+++ b/cmd/kube-resource-explorer/main.go
@@ -46,6 +46,7 @@ func main() {
 		prometheus_namespace = flag.String("prometheus_namespace", "monitoring", "select the prometheus namespace")
 		prometheus_pod       = flag.String("prometheus_pod", "prometheus-server", "select the prometheus pod")
 		csv                  = flag.Bool("csv", false, "Export results to csv file")
+		advise               = flag.Bool("advise", false, "Show Req/Lim advice")
 		kubeconfig           *string
 	)
 
@@ -104,7 +105,7 @@ func main() {
 			log.Exit(2)
 		}
 
-		k.Historical(promAddress, ctx, *namespace, resourceName, *duration, *sort, *reverse, *csv)
+		k.Historical(promAddress, ctx, *namespace, resourceName, *duration, *sort, *reverse, *csv, *advise)
 
 	} else {
 

--- a/pkg/kube/stackdriver.go
+++ b/pkg/kube/stackdriver.go
@@ -177,7 +177,7 @@ func (p *PrometheusClient) Worker(jobs <-chan *MetricJob, collector chan<- *Cont
 	close(collector)
 }
 
-func (k *KubeClient) Historical(promAddress string, ctx context.Context, namespace string, resourceName k8sv1.ResourceName, duration time.Duration, sort string, reverse bool, csv bool) {
+func (k *KubeClient) Historical(promAddress string, ctx context.Context, namespace string, resourceName k8sv1.ResourceName, duration time.Duration, sort string, reverse bool, csv bool, advise bool) {
 	promClient, err := NewPrometheusClient(promAddress)
 	if err != nil {
 		panic(err.Error())
@@ -192,7 +192,7 @@ func (k *KubeClient) Historical(promAddress string, ctx context.Context, namespa
 	collector := make(chan *ContainerMetrics)
 	go promClient.Worker(jobs, collector)
 	metrics := promClient.Run(jobs, collector, activePods, duration, resourceName)
-	rows, dataPoints := FormatContainerMetrics(metrics, resourceName, duration, sort, reverse)
+	rows, dataPoints := FormatContainerMetrics(metrics, resourceName, duration, sort, reverse, advise)
 
 	if csv {
 		prefix := "kube-resource-usage"


### PR DESCRIPTION
**Description:**
Modified the `FormatContainerMetrics` in `printer.go` and `Historical` method in `stackdriver.go` to enable resource request/limit recommendations for Kubernetes containers.