### PR TITLE
Add support for selecting Kubernetes context

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Resource Explorer
 
 ## Command Line Options                                                                                                
 * `-namespace` - Limit the query to the specified namespace (defaults to all)
+* `-context` - Select k8s context
 * `-sort` - Field to sort by
 * `-reverse` - Reserve the sort order
 * `-historical` - Display historical resource data
@@ -12,7 +13,9 @@ Resource Explorer
 * `-mem` - Show historical memory data
 * `-duration` - The duration to use for historical data (default to 4h)
 * `-prometheus_namespace` - Select the prometheus namespace (default: monitoring)
+* `prometheus_pod` - Select the prometheus pod (default: prometheus-server)
 * `-csv` - Export results to CSV file
+* `-advise` - Show Request/Limit advice
 
 ## Build
 ```

--- a/cmd/kube-resource-explorer/main.go
+++ b/cmd/kube-resource-explorer/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	log "github.com/Sirupsen/logrus"
+	"k8s.io/client-go/rest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,13 +18,19 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-var GitCommit string
-
 func homeDir() string {
 	if h := os.Getenv("HOME"); h != "" {
 		return h
 	}
 	return os.Getenv("USERPROFILE") // windows
+}
+
+func buildConfigWithContextFromFlags(context string, kubeconfigPath string) (*rest.Config, error) {
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfigPath},
+		&clientcmd.ConfigOverrides{
+			CurrentContext: context,
+		}).ClientConfig()
 }
 
 func main() {
@@ -36,15 +43,16 @@ func main() {
 	}
 
 	var (
-		namespace            = flag.String("namespace", "", "filter by namespace (defaults to all)")
-		sort                 = flag.String("sort", "CpuReq", "field to sort by")
-		reverse              = flag.Bool("reverse", false, "reverse sort output")
-		historical           = flag.Bool("historical", false, "show historical info")
-		duration             = flag.Duration("duration", default_duration, "specify the duration")
-		mem_only             = flag.Bool("mem", false, "show historical memory info")
-		cpu_only             = flag.Bool("cpu", false, "show historical cpu info")
-		prometheus_namespace = flag.String("prometheus_namespace", "monitoring", "select the prometheus namespace")
-		prometheus_pod       = flag.String("prometheus_pod", "prometheus-server", "select the prometheus pod")
+		namespace            = flag.String("namespace", "", "Filter by namespace (defaults to all)")
+		context_arg          = flag.String("context", "", "Select k8s context")
+		sort                 = flag.String("sort", "CpuReq", "Field to sort by")
+		reverse              = flag.Bool("reverse", false, "Reverse sort output")
+		historical           = flag.Bool("historical", false, "Show historical info")
+		duration             = flag.Duration("duration", default_duration, "Specify the duration")
+		mem_only             = flag.Bool("mem", false, "Show historical memory info")
+		cpu_only             = flag.Bool("cpu", false, "Show historical cpu info")
+		prometheus_namespace = flag.String("prometheus_namespace", "monitoring", "Select the prometheus namespace")
+		prometheus_pod       = flag.String("prometheus_pod", "prometheus-server", "Select the prometheus pod")
 		csv                  = flag.Bool("csv", false, "Export results to csv file")
 		advise               = flag.Bool("advise", false, "Show Req/Lim advice")
 		kubeconfig           *string
@@ -65,6 +73,11 @@ func main() {
 	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
 	if err != nil {
 		panic(err.Error())
+	}
+
+	config, err = buildConfigWithContextFromFlags(*context_arg, *kubeconfig)
+	if err != nil {
+		panic(err)
 	}
 
 	clientset, err := kubernetes.NewForConfig(config)


### PR DESCRIPTION
**Description:**
- Added a new command-line flag `-context` to enable users to choose the Kubernetes context.
- Modified the main function to incorporate context selection using the `buildConfigWithContextFromFlags` function.
- Updated the README to include details about the new `-context` flag.