### PR TITLE
Fix log.Fatalf format in error messages

### DIFF
--- a/pkg/kube/printer.go
+++ b/pkg/kube/printer.go
@@ -176,7 +176,7 @@ func AdvisingMultiple(metric string, suffix string) string {
 	RequestStr := strings.TrimSuffix(metric, suffix)
 	number, err := strconv.Atoi(RequestStr)
 	if err != nil {
-		log.Fatalln("Error converting request metric to int: %v", err)
+		log.Fatalf("Error converting request metric to int: %v\n", err)
 	}
 	square := number * 2
 	return fmt.Sprintf("%d%s", square, suffix)

--- a/pkg/kube/stackdriver.go
+++ b/pkg/kube/stackdriver.go
@@ -24,7 +24,7 @@ func NewPrometheusClient(address string) (*PrometheusClient, error) {
 		Address: address,
 	})
 	if err != nil {
-		log.Fatal("Failed to create Prometheus client: %s", err)
+		log.Fatalf("Failed to create Prometheus client: %s", err)
 	}
 
 	return &PrometheusClient{


### PR DESCRIPTION
<details>
<summary>Commit Details</summary>

Updated the usage of `log.Fatalln` to `log.Fatalf` in error handling code. This fixes the formatting issue, ensuring error messages are properly outputted with newline characters.

</details>